### PR TITLE
Add `className` attribute in settings for easier style override

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Following `settings` object properties can be used to configure the component.
 |defaultOpen|Boolean|false|To open the datepicker popover on load. Default is set to false.|
 |timePicker|Boolean|false|Enable time picker feature.|
 |closeOnSelect|Boolean|true|to close the popover on date select or on click of done button.|
-
+|className|String||Adds a custom class name to the parent element.|
 
 ## Callback Methods
 

--- a/src/app/angular2-datetimepicker/datepicker.component.html
+++ b/src/app/angular2-datetimepicker/datepicker.component.html
@@ -1,4 +1,4 @@
-<div class="winkel-calendar" (clickOutside)="closepopover()">
+<div [attr.class]="settings.className ? 'winkel-calendar ' + settings.className : 'winkel-calendar'" (clickOutside)="closepopover()">
     <span *ngIf="!settings.rangepicker">
     <input type="hidden" class="wc-input" value="{{date}}">
     <div class="wc-date-container" (click)="popover = !popover">

--- a/src/app/angular2-datetimepicker/interface.ts
+++ b/src/app/angular2-datetimepicker/interface.ts
@@ -9,4 +9,5 @@ export interface Settings{
     cal_months_labels_short: Array<string>;
     closeOnSelect?: boolean;
     rangepicker?: boolean;
+    className?: string;
 }


### PR DESCRIPTION
Added the ability for a user to define a `className` as part of the settings which will add the class they defined to the parent level HTML element of the date/time picker. This allows for easier CSS selection/customizations.